### PR TITLE
Change the way time ranges are stored in sections from array to ordered list.

### DIFF
--- a/src/main/java/com/google/sps/data/Section.java
+++ b/src/main/java/com/google/sps/data/Section.java
@@ -14,20 +14,26 @@
 
 package com.google.sps.data;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
 public class Section {
     private String professor;
-    private TimeRange[] meetingTimes;
-    /*
-    * meeting times is an array
-    * Where the 0th index is Sunday and the 6th is Saturday
-    * [_,_,_,_,_,_,_] no meeting times
-    * [_,*,_,*,_,*,_] class MWF
-    * [_,_,*,_,*,_,_] class TTh
-    * [*,_,_,_,_,_,*] class SatSun
-    */
-    public Section(String professor, TimeRange[] meetingTimes){
+    private List<TimeRange> meetingTimes;
+    // Meeting times will be sorted in ascending order of time, 
+    // with the first lesson being first in the list
+
+    public Section(String professor, List<TimeRange> meetingTimes){
         this.professor = professor;
         this.meetingTimes = meetingTimes;
+        Collections.sort(this.meetingTimes, TimeRange.ORDER_BY_START);
+
+        for(int i = 0; i < meetingTimes.size() - 1; i++){
+          if(meetingTimes.get(i).overlaps(meetingTimes.get(i + 1))) {
+            throw new IllegalArgumentException("A section's lecture times can't overlap!");
+          }
+        }
     }
 
     /**

--- a/src/main/java/com/google/sps/data/Section.java
+++ b/src/main/java/com/google/sps/data/Section.java
@@ -19,9 +19,9 @@ import java.util.List;
 
 public class Section {
     private String professor;
-    private List<TimeRange> meetingTimes;
     // Meeting times will be sorted in ascending order of time, 
     // with the first lesson being first in the list
+    private List<TimeRange> meetingTimes;
 
     public Section(String professor, List<TimeRange> meetingTimes){
         this.professor = professor;

--- a/src/main/java/com/google/sps/data/Section.java
+++ b/src/main/java/com/google/sps/data/Section.java
@@ -14,7 +14,6 @@
 
 package com.google.sps.data;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/com/google/sps/data/TimeRange.java
+++ b/src/main/java/com/google/sps/data/TimeRange.java
@@ -186,6 +186,12 @@ public final class TimeRange {
     return a.start == b.start && a.duration == b.duration;
   }
 
+  /**
+   * Returns the time in minutes given a day, for use when creating new timeRanges.
+   * @param hours an int representing the time (in hours) during the day
+   * @param minutes an int representing the time (in minutes) during the hour
+   * @return time in minutes during a week
+   */
   public static int getTimeInMinutes(int hours, int minutes) {
     if (hours < 0 || hours >= 24) {
       throw new IllegalArgumentException("Hours can only be 0 through 23 (inclusive).");
@@ -198,6 +204,13 @@ public final class TimeRange {
     return (hours * 60) + minutes;
   }
 
+  /**
+   * Returns the time in minutes given a day, for use when creating new timeRanges.
+   * @param day an int representing the day (0 being sunday, 6 being saturday)
+   * @param hours an int representing the time (in hours) during the day
+   * @param minutes an int representing the time (in minutes) during the hour
+   * @return time in minutes during a week
+   */
   public static int getTimeInMinutes(int day, int hours, int minutes){
     if (day < 0 || day >= 7) {
       throw new IllegalArgumentException("Day of the week must be between 0 and 6 (inclusive).");
@@ -260,7 +273,7 @@ public final class TimeRange {
   }
 
   /**
-   * Creates a {@code TimeRange} from {@code start} to {@code end}. Whether or not {@code end} is
+   * Creates a {@code TimeRange} from {@code start} (in minutes) to {@code end}. Whether or not {@code end} is
    * included in the range will depend on {@code inclusive}. If {@code inclusive} is {@code true},
    * then @{code end} will be in the range.
    */
@@ -269,7 +282,7 @@ public final class TimeRange {
   }
 
   /**
-   * Create a {@code TimeRange} starting at {@code start} with a duration equal to {@code duration}.
+   * Create a {@code TimeRange} starting at {@code start} (in minutes) with a duration equal to {@code duration}.
    */
   public static TimeRange fromStartDuration(int start, int duration) {
     return new TimeRange(start, duration);

--- a/src/main/java/com/google/sps/data/TimeRange.java
+++ b/src/main/java/com/google/sps/data/TimeRange.java
@@ -29,26 +29,26 @@ public final class TimeRange {
   public static final int FRIDAY = 5;
   public static final int SATURDAY = 6;
 
-  public static final int START_OF_SUNDAY = getTimeInMinutes(0, 0, 0);
-  public static final int END_OF_SUNDAY = getTimeInMinutes(0, 23, 59);
+  public static final int START_OF_SUNDAY = getTimeInMinutes(SUNDAY, 0, 0);
+  public static final int END_OF_SUNDAY = getTimeInMinutes(SUNDAY, 23, 59);
 
-  public static final int START_OF_MONDAY = getTimeInMinutes(1, 0, 0);
-  public static final int END_OF_MONDAY = getTimeInMinutes(1, 23, 59);
+  public static final int START_OF_MONDAY = getTimeInMinutes(MONDAY, 0, 0);
+  public static final int END_OF_MONDAY = getTimeInMinutes(MONDAY, 23, 59);
 
-  public static final int START_OF_TUESDAY = getTimeInMinutes(2, 0, 0);
-  public static final int END_OF_TUESDAY = getTimeInMinutes(2, 23, 59);
+  public static final int START_OF_TUESDAY = getTimeInMinutes(TUESDAY, 0, 0);
+  public static final int END_OF_TUESDAY = getTimeInMinutes(TUESDAY, 23, 59);
 
-  public static final int START_OF_WEDNESDAY = getTimeInMinutes(3, 0, 0);
-  public static final int END_OF_WEDNESDAY = getTimeInMinutes(3, 23, 59);
+  public static final int START_OF_WEDNESDAY = getTimeInMinutes(WEDNESDAY, 0, 0);
+  public static final int END_OF_WEDNESDAY = getTimeInMinutes(WEDNESDAY, 23, 59);
 
-  public static final int START_OF_THURSDAY = getTimeInMinutes(4, 0, 0);
-  public static final int END_OF_THURSDAY = getTimeInMinutes(4, 23, 59);
+  public static final int START_OF_THURSDAY = getTimeInMinutes(THURSDAY, 0, 0);
+  public static final int END_OF_THURSDAY = getTimeInMinutes(THURSDAY, 23, 59);
 
-  public static final int START_OF_FRIDAY = getTimeInMinutes(5, 0, 0);
-  public static final int END_OF_FRIDAY = getTimeInMinutes(5, 23, 59);
+  public static final int START_OF_FRIDAY = getTimeInMinutes(FRIDAY, 0, 0);
+  public static final int END_OF_FRIDAY = getTimeInMinutes(FRIDAY, 23, 59);
 
-  public static final int START_OF_SATURDAY = getTimeInMinutes(6, 0, 0);
-  public static final int END_OF_SATURDAY = getTimeInMinutes(6, 23, 59);
+  public static final int START_OF_SATURDAY = getTimeInMinutes(SATURDAY, 0, 0);
+  public static final int END_OF_SATURDAY = getTimeInMinutes(SATURDAY, 23, 59);
 
   public static final int START_OF_WEEK = getTimeInMinutes(0, 0);
   public static final int END_OF_WEEK = getTimeInMinutes(6, 23, 59);

--- a/src/main/java/com/google/sps/data/TimeRange.java
+++ b/src/main/java/com/google/sps/data/TimeRange.java
@@ -29,29 +29,29 @@ public final class TimeRange {
   public static final int FRIDAY = 5;
   public static final int SATURDAY = 6;
 
-  public static final int START_OF_SUNDAY = getTimeInMinutes(SUNDAY, 0, 0);
-  public static final int END_OF_SUNDAY = getTimeInMinutes(SUNDAY, 23, 59);
+  public static final int START_OF_SUNDAY = convertTimeToMinutes(SUNDAY, 0, 0);
+  public static final int END_OF_SUNDAY = convertTimeToMinutes(SUNDAY, 23, 59);
 
-  public static final int START_OF_MONDAY = getTimeInMinutes(MONDAY, 0, 0);
-  public static final int END_OF_MONDAY = getTimeInMinutes(MONDAY, 23, 59);
+  public static final int START_OF_MONDAY = convertTimeToMinutes(MONDAY, 0, 0);
+  public static final int END_OF_MONDAY = convertTimeToMinutes(MONDAY, 23, 59);
 
-  public static final int START_OF_TUESDAY = getTimeInMinutes(TUESDAY, 0, 0);
-  public static final int END_OF_TUESDAY = getTimeInMinutes(TUESDAY, 23, 59);
+  public static final int START_OF_TUESDAY = convertTimeToMinutes(TUESDAY, 0, 0);
+  public static final int END_OF_TUESDAY = convertTimeToMinutes(TUESDAY, 23, 59);
 
-  public static final int START_OF_WEDNESDAY = getTimeInMinutes(WEDNESDAY, 0, 0);
-  public static final int END_OF_WEDNESDAY = getTimeInMinutes(WEDNESDAY, 23, 59);
+  public static final int START_OF_WEDNESDAY = convertTimeToMinutes(WEDNESDAY, 0, 0);
+  public static final int END_OF_WEDNESDAY = convertTimeToMinutes(WEDNESDAY, 23, 59);
 
-  public static final int START_OF_THURSDAY = getTimeInMinutes(THURSDAY, 0, 0);
-  public static final int END_OF_THURSDAY = getTimeInMinutes(THURSDAY, 23, 59);
+  public static final int START_OF_THURSDAY = convertTimeToMinutes(THURSDAY, 0, 0);
+  public static final int END_OF_THURSDAY = convertTimeToMinutes(THURSDAY, 23, 59);
 
-  public static final int START_OF_FRIDAY = getTimeInMinutes(FRIDAY, 0, 0);
-  public static final int END_OF_FRIDAY = getTimeInMinutes(FRIDAY, 23, 59);
+  public static final int START_OF_FRIDAY = convertTimeToMinutes(FRIDAY, 0, 0);
+  public static final int END_OF_FRIDAY = convertTimeToMinutes(FRIDAY, 23, 59);
 
-  public static final int START_OF_SATURDAY = getTimeInMinutes(SATURDAY, 0, 0);
-  public static final int END_OF_SATURDAY = getTimeInMinutes(SATURDAY, 23, 59);
+  public static final int START_OF_SATURDAY = convertTimeToMinutes(SATURDAY, 0, 0);
+  public static final int END_OF_SATURDAY = convertTimeToMinutes(SATURDAY, 23, 59);
 
-  public static final int START_OF_WEEK = getTimeInMinutes(0, 0);
-  public static final int END_OF_WEEK = getTimeInMinutes(6, 23, 59);
+  public static final int START_OF_WEEK = convertTimeToMinutes(0, 0);
+  public static final int END_OF_WEEK = convertTimeToMinutes(6, 23, 59);
 
   public static final int WHOLE_DAY_DURATION = 24 * 60;
   public static final TimeRange WHOLE_WEEK = new TimeRange(0, 24 * 7 * 60);
@@ -192,7 +192,7 @@ public final class TimeRange {
    * @param minutes an int representing the time (in minutes) during the hour
    * @return time in minutes during a week
    */
-  public static int getTimeInMinutes(int hours, int minutes) {
+  public static int convertTimeToMinutes(int hours, int minutes) {
     if (hours < 0 || hours >= 24) {
       throw new IllegalArgumentException("Hours can only be 0 through 23 (inclusive).");
     }
@@ -211,7 +211,7 @@ public final class TimeRange {
    * @param minutes an int representing the time (in minutes) during the hour
    * @return time in minutes during a week
    */
-  public static int getTimeInMinutes(int day, int hours, int minutes){
+  public static int convertTimeToMinutes(int day, int hours, int minutes) {
     if (day < 0 || day >= 7) {
       throw new IllegalArgumentException("Day of the week must be between 0 and 6 (inclusive).");
     }
@@ -227,31 +227,12 @@ public final class TimeRange {
     return (day * 24 * 60) + (hours * 60) + minutes;
   }
 
-  /**
-   * Returns the day of the week in int form (0 being sunday, 6 being saturday)
-   * @param hours
-   * @param minutes
-   * @return int representing the day of the week
-   */
-  public static int getDayOfWeek(int hours, int minutes) {
-    if (hours < 0 || hours > 24 * 7) {
-      throw new IllegalArgumentException("Hours must be within a week period (between 0 and 167, inclusive).");
-    }
-
-    if (minutes < 0 || minutes >= 60) {
-      throw new IllegalArgumentException("Minutes can only be 0 through 59 (inclusive).");
-    }
-
-    return (int) Math.floorDiv(hours, 24);
-  }
-
     /**
-   * Returns the day of the week in int form (0 being sunday, 6 being saturday)
-   * @param hours
-   * @param minutes
+   * Returns the day of the week in int form (0 being sunday, 6 being saturday).
+   * @param hours The hours in the timeframe
    * @return int representing the day of the week
    */
-  public static int getDayOfWeekHours(int hours) {
+  public static int hoursToDayOfWeek (int hours) {
     if (hours < 0 || hours > 24 * 7) {
       throw new IllegalArgumentException("Time must be within a week period (between 0 and 167, inclusive).");
     }
@@ -264,7 +245,7 @@ public final class TimeRange {
    * @param minutes
    * @return int representing the day of the week
    */
-  public static int getDayOfWeekMinutes(int minutes) {
+  public static int minutesToDayOfWeek (int minutes) {
     if (minutes < 0 || minutes > 24 * 7 * 60) {
       throw new IllegalArgumentException("Time must be within a week period (between 0 and 10079, inclusive).");
     }

--- a/src/main/java/com/google/sps/data/TimeRange.java
+++ b/src/main/java/com/google/sps/data/TimeRange.java
@@ -21,10 +21,32 @@ import java.util.Comparator;
  * providing methods to make ranges easier to work with (e.g. {@code overlaps}).
  */
 public final class TimeRange {
-  public static final int START_OF_DAY = getTimeInMinutes(0, 0);
-  public static final int END_OF_DAY = getTimeInMinutes(23, 59);
+  public static final int START_OF_SUNDAY = getTimeInMinutes(0, 0, 0);
+  public static final int END_OF_SUNDAY = getTimeInMinutes(0, 23, 59);
 
-  public static final TimeRange WHOLE_DAY = new TimeRange(0, 24 * 60);
+  public static final int START_OF_MONDAY = getTimeInMinutes(1, 0, 0);
+  public static final int END_OF_MONDAY = getTimeInMinutes(1, 23, 59);
+
+  public static final int START_OF_TUESDAY = getTimeInMinutes(2, 0, 0);
+  public static final int END_OF_TUESDAY = getTimeInMinutes(2, 23, 59);
+
+  public static final int START_OF_WEDNESDAY = getTimeInMinutes(3, 0, 0);
+  public static final int END_OF_WEDNESDAY = getTimeInMinutes(3, 23, 59);
+
+  public static final int START_OF_THURSDAY = getTimeInMinutes(4, 0, 0);
+  public static final int END_OF_THURSDAY = getTimeInMinutes(4, 23, 59);
+
+  public static final int START_OF_FRIDAY = getTimeInMinutes(5, 0, 0);
+  public static final int END_OF_FRIDAY = getTimeInMinutes(5, 23, 59);
+
+  public static final int START_OF_SATURDAY = getTimeInMinutes(6, 0, 0);
+  public static final int END_OF_SATURDAY = getTimeInMinutes(6, 23, 59);
+
+  public static final int START_OF_WEEK = getTimeInMinutes(0, 0);
+  public static final int END_OF_WEEK = getTimeInMinutes(6, 23, 59);
+
+  public static final int WHOLE_DAY_DURATION = 24 * 60;
+  public static final TimeRange WHOLE_WEEK = new TimeRange(0, 24 * 7 * 60);
 
   /**
    * A comparator for sorting ranges by their start time in ascending order.
@@ -166,6 +188,67 @@ public final class TimeRange {
     }
 
     return (hours * 60) + minutes;
+  }
+
+  public static int getTimeInMinutes(int day, int hours, int minutes){
+    if (day < 0 || day >= 7) {
+      throw new IllegalArgumentException("Day of the week must be between 0 and 6 (inclusive).");
+    }
+
+    if (hours < 0 || hours >= 24) {
+      throw new IllegalArgumentException("Hours can only be 0 through 23 (inclusive).");
+    }
+
+    if (minutes < 0 || minutes >= 60) {
+      throw new IllegalArgumentException("Minutes can only be 0 through 59 (inclusive).");
+    }
+
+    return (day * 24 * 60) + (hours * 60) + minutes;
+  }
+
+  /**
+   * Returns the day of the week in int form (0 being sunday, 6 being saturday)
+   * @param hours
+   * @param minutes
+   * @return int representing the day of the week
+   */
+  public static int getDayOfWeek(int hours, int minutes) {
+    if (hours < 0 || hours > 24 * 7) {
+      throw new IllegalArgumentException("Hours must be within a week period (between 0 and 167, inclusive).");
+    }
+
+    if (minutes < 0 || minutes >= 60) {
+      throw new IllegalArgumentException("Minutes can only be 0 through 59 (inclusive).");
+    }
+
+    return (int) Math.floorDiv(hours, 24);
+  }
+
+    /**
+   * Returns the day of the week in int form (0 being sunday, 6 being saturday)
+   * @param hours
+   * @param minutes
+   * @return int representing the day of the week
+   */
+  public static int getDayOfWeekHours(int hours) {
+    if (hours < 0 || hours > 24 * 7) {
+      throw new IllegalArgumentException("Time must be within a week period (between 0 and 167, inclusive).");
+    }
+
+    return (int) Math.floorDiv(hours, 24);
+  }
+
+  /**
+   * Returns the day of the week in int form (0 being sunday, 6 being saturday)
+   * @param minutes
+   * @return int representing the day of the week
+   */
+  public static int getDayOfWeekMinutes(int minutes) {
+    if (minutes < 0 || minutes > 24 * 7 * 60) {
+      throw new IllegalArgumentException("Time must be within a week period (between 0 and 10079, inclusive).");
+    }
+
+    return (int) Math.floorDiv(minutes, 24 * 60);
   }
 
   /**

--- a/src/main/java/com/google/sps/data/TimeRange.java
+++ b/src/main/java/com/google/sps/data/TimeRange.java
@@ -29,27 +29,6 @@ public final class TimeRange {
   public static final int FRIDAY = 5;
   public static final int SATURDAY = 6;
 
-  public static final int START_OF_SUNDAY = convertTimeToMinutes(SUNDAY, 0, 0);
-  public static final int END_OF_SUNDAY = convertTimeToMinutes(SUNDAY, 23, 59);
-
-  public static final int START_OF_MONDAY = convertTimeToMinutes(MONDAY, 0, 0);
-  public static final int END_OF_MONDAY = convertTimeToMinutes(MONDAY, 23, 59);
-
-  public static final int START_OF_TUESDAY = convertTimeToMinutes(TUESDAY, 0, 0);
-  public static final int END_OF_TUESDAY = convertTimeToMinutes(TUESDAY, 23, 59);
-
-  public static final int START_OF_WEDNESDAY = convertTimeToMinutes(WEDNESDAY, 0, 0);
-  public static final int END_OF_WEDNESDAY = convertTimeToMinutes(WEDNESDAY, 23, 59);
-
-  public static final int START_OF_THURSDAY = convertTimeToMinutes(THURSDAY, 0, 0);
-  public static final int END_OF_THURSDAY = convertTimeToMinutes(THURSDAY, 23, 59);
-
-  public static final int START_OF_FRIDAY = convertTimeToMinutes(FRIDAY, 0, 0);
-  public static final int END_OF_FRIDAY = convertTimeToMinutes(FRIDAY, 23, 59);
-
-  public static final int START_OF_SATURDAY = convertTimeToMinutes(SATURDAY, 0, 0);
-  public static final int END_OF_SATURDAY = convertTimeToMinutes(SATURDAY, 23, 59);
-
   public static final int START_OF_WEEK = convertTimeToMinutes(0, 0);
   public static final int END_OF_WEEK = convertTimeToMinutes(6, 23, 59);
 
@@ -232,7 +211,7 @@ public final class TimeRange {
    * @param hours The hours in the timeframe
    * @return int representing the day of the week
    */
-  public static int hoursToDayOfWeek (int hours) {
+  public static int hoursToDayOfWeek(int hours) {
     if (hours < 0 || hours > 24 * 7) {
       throw new IllegalArgumentException("Time must be within a week period (between 0 and 167, inclusive).");
     }
@@ -245,7 +224,7 @@ public final class TimeRange {
    * @param minutes
    * @return int representing the day of the week
    */
-  public static int minutesToDayOfWeek (int minutes) {
+  public static int minutesToDayOfWeek(int minutes) {
     if (minutes < 0 || minutes > 24 * 7 * 60) {
       throw new IllegalArgumentException("Time must be within a week period (between 0 and 10079, inclusive).");
     }
@@ -254,18 +233,38 @@ public final class TimeRange {
   }
 
   /**
-   * Creates a {@code TimeRange} from {@code start} (in minutes) to {@code end}. Whether or not {@code end} is
-   * included in the range will depend on {@code inclusive}. If {@code inclusive} is {@code true},
-   * then @{code end} will be in the range.
+   * Creates a TimeRange given a start time, end time, 
+   * and if the end of the event is inclusive or not.
+   * 
+   * @param startDay The day on which the event starts,
+   *                 represented by an int (0 being sunday, 6 being saturday)
+   * @param startHour The hour in the day when the event starts.
+   * @param startMinutes The minute in the hour when the event starts.
+   * @param endDay The day on which the event ends
+   * @param endHour The hour in the day when the event ends
+   * @param endMinutes The minute in the hour when the event ends
+   * @param inclusive Whether or not the event end time is inclusive or not
+   * @return a TimeRange given start time and end time
    */
-  public static TimeRange fromStartEnd(int start, int end, boolean inclusive) {
+  public static TimeRange fromStartEnd(int startDay, int startHour, int startMinutes, 
+      int endDay, int endHour, int endMinutes, boolean inclusive) {
+    int start = convertTimeToMinutes(startDay, startHour, startMinutes);
+    int end = convertTimeToMinutes(endDay, endHour, endMinutes);
     return inclusive ? new TimeRange(start, end - start + 1) : new TimeRange(start, end - start);
   }
 
   /**
-   * Create a {@code TimeRange} starting at {@code start} (in minutes) with a duration equal to {@code duration}.
+   * Creates a TimeRange from the start time (described in date, hours, and minutes) of duration
+   * in minutes specified by duration.
+   * 
+   * @param day the day on which the event starts, 
+   *            represented by an int (0 being sunday, 6 being saturday)
+   * @param hour The hour in the day when the event starts
+   * @param minutes The minute in the hour when the event starts
+   * @param durationMinutes the duration, in minutes of the event
+   * @return a TimeRange given start time and duration
    */
-  public static TimeRange fromStartDuration(int start, int duration) {
-    return new TimeRange(start, duration);
+  public static TimeRange fromStartDuration(int day, int hour, int minutes, int durationMinutes) {
+    return new TimeRange(convertTimeToMinutes(day, hour, minutes), durationMinutes);
   }
 }

--- a/src/main/java/com/google/sps/data/TimeRange.java
+++ b/src/main/java/com/google/sps/data/TimeRange.java
@@ -21,6 +21,14 @@ import java.util.Comparator;
  * providing methods to make ranges easier to work with (e.g. {@code overlaps}).
  */
 public final class TimeRange {
+  public static final int SUNDAY = 0;
+  public static final int MONDAY = 1;
+  public static final int TUESDAY = 2;
+  public static final int WEDNESDAY = 3;
+  public static final int THURSDAY = 4;
+  public static final int FRIDAY = 5;
+  public static final int SATURDAY = 6;
+
   public static final int START_OF_SUNDAY = getTimeInMinutes(0, 0, 0);
   public static final int END_OF_SUNDAY = getTimeInMinutes(0, 23, 59);
 


### PR DESCRIPTION
This changes TimeRange to work over a week long period, as opposed to a 24h period. I also added some helpful functions re: being over a week-long period to TimeRange.
It'll be useful to add some more checks, both in the section and in the frontend, for if the user inputs an impossible section/class (like the check in the `Section.java` constructor for overlapping class times within the same section). This could include having an unreasonably long meeting time (something like a 12 hours long etc). 