### PR TITLE
Fix bug where non-Required courses weren't being properly added to schedules

### DIFF
--- a/src/main/java/com/google/sps/Scheduler.java
+++ b/src/main/java/com/google/sps/Scheduler.java
@@ -59,10 +59,11 @@ public final class Scheduler {
    * Recursively iterates through a list of courses and adds schedules to the
    * given set.
    * 
-   * @param courses     The list of courses to iterate through
-   * @param currentSchedule  The current scheduled course list to be added/operated on
-   * @param invariants  The invariants that constrain the valid schedules
-   * @param courseLists The set of course lists that is being generated/added to.
+   * @param index                         The index the current course in availableCourses
+   * @param availableCourses              The list of courses to iterate through
+   * @param currentSchedule               The current scheduled course list to be added/operated on
+   * @param invariants                    The invariants that constrain the valid schedules
+   * @param generatedScheduledCourseLists The set of scheduledCourse lists that is being generated/added to.
    */
   private void generateSchedulesHelper(int index, List<Course> availableCourses, List<ScheduledCourse> currentSchedule,
       Invariants invariants, Set<List<ScheduledCourse>> generatedScheduledCourseLists) {
@@ -117,7 +118,7 @@ public final class Scheduler {
           if (doesNotOverlapSchedule) {
             List<ScheduledCourse> newScheduledCourseList = new ArrayList<>(currentSchedule);
             newScheduledCourseList.add(new ScheduledCourse(course, lectureSection));
-            generateSchedulesHelper(index +1, availableCourses, 
+            generateSchedulesHelper(index + 1, availableCourses, 
                 newScheduledCourseList, invariants, generatedScheduledCourseLists);
           }
         }

--- a/src/main/java/com/google/sps/Scheduler.java
+++ b/src/main/java/com/google/sps/Scheduler.java
@@ -38,13 +38,13 @@ public final class Scheduler {
     float reqCredits = totalCredits(requiredCourses);
     Set<List<ScheduledCourse>> requiredSet = new HashSet<>();
 
-    generateSchedulesHelper(requiredCourses, new ArrayList<>(), 
+    generateSchedulesHelper(0, requiredCourses, new ArrayList<>(), 
         new Invariants(reqCredits, reqCredits), requiredSet);
     
     // Using those Schedules as a building block, generate all valid schedules
     Set<List<ScheduledCourse>> scheduleSet = new HashSet<>();
     for (List<ScheduledCourse> requiredCourseList : requiredSet) {
-      generateSchedulesHelper(nonRequiredCourses, requiredCourseList, invariants, scheduleSet);
+      generateSchedulesHelper(0, nonRequiredCourses, requiredCourseList, invariants, scheduleSet);
     }
 
     List<Schedule> schedules = new ArrayList<>();
@@ -64,7 +64,7 @@ public final class Scheduler {
    * @param invariants  The invariants that constrain the valid schedules
    * @param courseLists The set of course lists that is being generated/added to.
    */
-  private void generateSchedulesHelper(List<Course> availableCourses, List<ScheduledCourse> currentSchedule,
+  private void generateSchedulesHelper(int index, List<Course> availableCourses, List<ScheduledCourse> currentSchedule,
       Invariants invariants, Set<List<ScheduledCourse>> generatedScheduledCourseLists) {
 
     // This means that we have a valid schedule, and should add it to the list.
@@ -74,11 +74,11 @@ public final class Scheduler {
     }
 
     // We've reached the end of the list or have a full schedule, we are finished.
-    if (availableCourses.isEmpty() || currCredits > invariants.getMaxCredits()) {
+    if (index >= availableCourses.size() || currCredits > invariants.getMaxCredits()) {
       return;
     }
 
-    Course course = availableCourses.remove(0);
+    Course course = availableCourses.get(index);
     List<Section> courseLectureSections = course.getLectureSections();
     List<Section> courseLabSections = course.getLabSections();
     boolean hasLabs = !courseLabSections.isEmpty();
@@ -106,7 +106,7 @@ public final class Scheduler {
           if (doesNotOverlapSchedule) {
             List<ScheduledCourse> newScheduledCourseList = new ArrayList<>(currentSchedule);
             newScheduledCourseList.add(new ScheduledCourse(course, lectureSection, labSection));
-            generateSchedulesHelper(new ArrayList<>(availableCourses), 
+            generateSchedulesHelper(index + 1, availableCourses, 
                 newScheduledCourseList, invariants, generatedScheduledCourseLists);
           }
         }
@@ -117,7 +117,7 @@ public final class Scheduler {
           if (doesNotOverlapSchedule) {
             List<ScheduledCourse> newScheduledCourseList = new ArrayList<>(currentSchedule);
             newScheduledCourseList.add(new ScheduledCourse(course, lectureSection));
-            generateSchedulesHelper(new ArrayList<>(availableCourses), 
+            generateSchedulesHelper(index +1, availableCourses, 
                 newScheduledCourseList, invariants, generatedScheduledCourseLists);
           }
         }
@@ -126,7 +126,7 @@ public final class Scheduler {
 
     //If a course is not required, continue permuting with it *not* added to the schedule
     if (!course.isRequired()) {
-      generateSchedulesHelper(new ArrayList<>(availableCourses), 
+      generateSchedulesHelper(index + 1, availableCourses, 
           currentSchedule, invariants, generatedScheduledCourseLists);
     }
   }

--- a/src/main/java/com/google/sps/data/ScheduledCourse.java
+++ b/src/main/java/com/google/sps/data/ScheduledCourse.java
@@ -108,7 +108,7 @@ public class ScheduledCourse extends Course {
     return super.hashCode() * Objects.hash(lectureSection, labSection);
   }
 
-  public Section getlectureSection() {
+  public Section getLectureSection() {
     return this.lectureSection;
   }
 

--- a/src/test/java/com/google/sps/SchedulerTest.java
+++ b/src/test/java/com/google/sps/SchedulerTest.java
@@ -341,7 +341,7 @@ public final class SchedulerTest {
     Course course2 = new Course("Research and Innovation in Computer Science", "15300", 
     "Computer Science", 9, true, section2, recitation2);
 
-    // COMPILIERS
+    // COMPILERS
     List<Section> section3 = Arrays.asList(new Section("Professor C", tuesThurs(8, 00, DURATION_90_MINUTES)));
     List<Section> recitation3 = Arrays.asList(new Section("Professor C", Arrays.asList(TimeRange.fromStartDuration(TimeRange.FRIDAY, 14, 30, DURATION_1_HOUR))),
                                               new Section("Professor C", Arrays.asList(TimeRange.fromStartDuration(TimeRange.FRIDAY, 16, 00, DURATION_1_HOUR))));

--- a/src/test/java/com/google/sps/SchedulerTest.java
+++ b/src/test/java/com/google/sps/SchedulerTest.java
@@ -35,6 +35,7 @@ public final class SchedulerTest {
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
   private static final int DURATION_1_HOUR = 60;
+  private static final int DURATION_2_HOUR = 120;
   
 
   private Scheduler scheduler;
@@ -52,6 +53,33 @@ public final class SchedulerTest {
     TimeRange wed = TimeRange.fromStartDuration(TimeRange.WEDNESDAY, hour, minute, durationMinutes);
     TimeRange fri = TimeRange.fromStartDuration(TimeRange.FRIDAY, hour, minute, durationMinutes);
     return Arrays.asList(mon, wed, fri);
+  }
+
+  /**
+   * Returns a list of times on monday and friday, to be used in section constructors.
+   */
+  public List<TimeRange> monFri(int hour, int minute, int durationMinutes) {
+    TimeRange mon = TimeRange.fromStartDuration(TimeRange.MONDAY, hour, minute, durationMinutes);
+    TimeRange fri = TimeRange.fromStartDuration(TimeRange.FRIDAY, hour, minute, durationMinutes);
+    return Arrays.asList(mon, fri);
+  }
+
+  /**
+   * Returns a list of times on monday and friday, to be used in section constructors.
+   */
+  public List<TimeRange> monWed(int hour, int minute, int durationMinutes) {
+    TimeRange mon = TimeRange.fromStartDuration(TimeRange.MONDAY, hour, minute, durationMinutes);
+    TimeRange wed = TimeRange.fromStartDuration(TimeRange.WEDNESDAY, hour, minute, durationMinutes);
+    return Arrays.asList(mon, wed);
+  }
+
+    /**
+   * Returns a list of times on monday, wednesday, and friday, to be used in section constructors.
+   */
+  public List<TimeRange> wedFri(int hour, int minute, int durationMinutes) {
+    TimeRange wed = TimeRange.fromStartDuration(TimeRange.WEDNESDAY, hour, minute, durationMinutes);
+    TimeRange fri = TimeRange.fromStartDuration(TimeRange.FRIDAY, hour, minute, durationMinutes);
+    return Arrays.asList(wed, fri);
   }
 
   /**
@@ -296,5 +324,50 @@ public final class SchedulerTest {
     HashSet<Schedule> expected = new HashSet<>(Arrays.asList(schedule1, schedule2, schedule3, schedule4));
 
     Assert.assertEquals(expected, actual);
+  }
+
+  public List<Course> createTrash() {
+    // PARALLEL ALGORITHMS
+    List<Section> section1 = Arrays.asList(new Section("Professor A", monWedFri(9, 30, DURATION_2_HOUR)));
+    List<Section> recitation1 = Arrays.asList(new Section("Professor A", Arrays.asList(TimeRange.fromStartDuration(TimeRange.TUESDAY, 10, 30, DURATION_1_HOUR))),
+                                              new Section("Professor A", Arrays.asList(TimeRange.fromStartDuration(TimeRange.TUESDAY, 11, 30, DURATION_1_HOUR))));
+    Course course1 = new Course("Parallel and Sequential Data Structures and Algorithms", 
+    "15210", "Computer Science", 12, true, section1, recitation1);
+
+    // RESEARCH AND INNOVATION
+    List<Section> section2 = Arrays.asList(new Section("Professor B", monFri(11, 30, DURATION_90_MINUTES)),
+                                           new Section("Professor B", wedFri(11, 30, DURATION_90_MINUTES)));
+    List<Section> recitation2 = Arrays.asList();
+    Course course2 = new Course("Research and Innovation in Computer Science", "15300", 
+    "Computer Science", 9, true, section2, recitation2);
+
+    // COMPILIERS
+    List<Section> section3 = Arrays.asList(new Section("Professor C", tuesThurs(8, 00, DURATION_90_MINUTES)));
+    List<Section> recitation3 = Arrays.asList(new Section("Professor C", Arrays.asList(TimeRange.fromStartDuration(TimeRange.FRIDAY, 14, 30, DURATION_1_HOUR))),
+                                              new Section("Professor C", Arrays.asList(TimeRange.fromStartDuration(TimeRange.FRIDAY, 16, 00, DURATION_1_HOUR))));
+    Course course3 = new Course("Compiler Design", "15411", 
+    "Computer Science", 15, true, section3, recitation3);
+
+    // ORGANIZATIONAL BEHAVIOR
+    List<Section> section4 = Arrays.asList(new Section("Professor D", monWed(13, 30, DURATION_2_HOUR)),
+                                           new Section("Professor D", tuesThurs(15, 00, DURATION_2_HOUR)));
+    List<Section> recitation4 = Arrays.asList();
+    Course course4 = new Course("Organizational Behavior", 
+    "70311", "Tepper", 9, false, section4, recitation4);
+
+    // INTRO TO CIVIL ENGINEERING
+    List<Section> section5 = Arrays.asList(new Section("Professor E", Arrays.asList(TimeRange.fromStartDuration(TimeRange.WEDNESDAY, 16, 00, DURATION_2_HOUR))));
+    List<Section> recitation5 = Arrays.asList(new Section("Professor E", monFri(16,00, DURATION_1_HOUR)));
+    Course course5 = new Course("Intro to Civil Engineering", 
+    "12100", "Civil Engineering", 12, false, section5, recitation5);
+
+    return Arrays.asList(course1, course2, course3, course4, course5);
+  }
+
+  @Test
+  public void bigTestWeird() {
+    List<Course> courses = createTrash();
+    List<Schedule> schedules = scheduler.generateSchedules(courses, new Invariants(54, 60));
+    System.out.println("woo");
   }
 }

--- a/src/test/java/com/google/sps/SchedulerTest.java
+++ b/src/test/java/com/google/sps/SchedulerTest.java
@@ -326,7 +326,7 @@ public final class SchedulerTest {
     Assert.assertEquals(expected, actual);
   }
 
-  public List<Course> createTrash() {
+  public List<Course> generateLargeSchedule() {
     // PARALLEL ALGORITHMS
     List<Section> section1 = Arrays.asList(new Section("Professor A", monWedFri(9, 30, DURATION_2_HOUR)));
     List<Section> recitation1 = Arrays.asList(new Section("Professor A", Arrays.asList(TimeRange.fromStartDuration(TimeRange.TUESDAY, 10, 30, DURATION_1_HOUR))),
@@ -365,9 +365,9 @@ public final class SchedulerTest {
   }
 
   @Test
-  public void bigTestWeird() {
-    List<Course> courses = createTrash();
+  public void nonRequiredNotDeleted() {
+    List<Course> courses = generateLargeSchedule();
     List<Schedule> schedules = scheduler.generateSchedules(courses, new Invariants(54, 60));
-    System.out.println("woo");
+    Assert.assertTrue(schedules.size() == 8);
   }
 }


### PR DESCRIPTION
As a fun side effect, `scheduler.generateSchedulesHelper` is now more space efficient